### PR TITLE
Add loading spinner and async startup

### DIFF
--- a/PackageAnalyzer/App.xaml.cs
+++ b/PackageAnalyzer/App.xaml.cs
@@ -21,7 +21,7 @@ namespace PackageAnalyzer
             
         }
 
-        protected override void OnStartup(StartupEventArgs e)
+        protected override async void OnStartup(StartupEventArgs e)
         {
             // Get the directory where the executable resides
             var exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
@@ -40,8 +40,14 @@ namespace PackageAnalyzer
                 AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
                 DispatcherUnhandledException += App_DispatcherUnhandledException;
             }
-            MainWindow mainWindow = new MainWindow(e.Args);
+            LoadingWindow loadingWindow = new LoadingWindow();
+            loadingWindow.Show();
+
+            MainWindow mainWindow = new MainWindow();
+            await mainWindow.InitializeAsync(e.Args);
+            MainWindow = mainWindow;
             mainWindow.Show();
+            loadingWindow.Close();
         }
 
         protected override void OnExit(ExitEventArgs e)

--- a/PackageAnalyzer/LoadingWindow.xaml
+++ b/PackageAnalyzer/LoadingWindow.xaml
@@ -1,0 +1,13 @@
+<Window x:Class="PackageAnalyzer.LoadingWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        WindowStyle="None" ResizeMode="NoResize" ShowInTaskbar="False"
+        AllowsTransparency="True" Background="Transparent" Width="200" Height="100"
+        WindowStartupLocation="CenterScreen">
+    <Border Background="White" CornerRadius="10" Padding="20">
+        <StackPanel>
+            <TextBlock Text="Loading..." HorizontalAlignment="Center" Margin="0,0,0,10"/>
+            <ProgressBar IsIndeterminate="True" Width="150" Height="20"/>
+        </StackPanel>
+    </Border>
+</Window>

--- a/PackageAnalyzer/LoadingWindow.xaml.cs
+++ b/PackageAnalyzer/LoadingWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace PackageAnalyzer
+{
+    public partial class LoadingWindow : Window
+    {
+        public LoadingWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `LoadingWindow` with spinner
- show loading window during startup and perform async initialization
- convert MainWindow initialization and file processing to async
- update event handlers to await new async methods

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4880e4a483269af40d6a689fa232