### PR TITLE
Ensure ListView columns autosize

### DIFF
--- a/PackageAnalyzer/MainWindow.xaml
+++ b/PackageAnalyzer/MainWindow.xaml
@@ -3,7 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:av="http://schemas.microsoft.com/expression/blend/2008" 
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-        xmlns:local="clr-namespace:PackageAnalyzer.Data" mc:Ignorable="av" x:Class="PackageAnalyzer.MainWindow" 
+        xmlns:local="clr-namespace:PackageAnalyzer.Data"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        mc:Ignorable="av"
+        x:Class="PackageAnalyzer.MainWindow"
         Title="Package Analyzer" Height="800
     " Width="1000"
     WindowState="Maximized"
@@ -110,8 +113,8 @@
           ScrollViewer.IsDeferredScrollingEnabled="True">
             <ListView.View>
                 <GridView>
-                    <GridViewColumn Header="Key" DisplayMemberBinding="{Binding Identifier}" />
-                    <GridViewColumn Header="Result">
+                    <GridViewColumn Header="Key" DisplayMemberBinding="{Binding Identifier}" Width="{x:Static sys:Double.NaN}" />
+                    <GridViewColumn Header="Result" Width="{x:Static sys:Double.NaN}">
                         <GridViewColumn.CellTemplateSelector>
                             <local:ValueTemplateSelector />
                         </GridViewColumn.CellTemplateSelector>

--- a/PackageAnalyzer/MainWindow.xaml.cs
+++ b/PackageAnalyzer/MainWindow.xaml.cs
@@ -202,6 +202,15 @@ namespace PackageAnalyzer
         private void AddRowToDataGrid()
         {
             SitecoreDataGrid.ItemsSource = dataToShow;
+
+            if (SitecoreDataGrid.View is GridView gridView)
+            {
+                foreach (var column in gridView.Columns)
+                {
+                    column.Width = column.ActualWidth;
+                    column.Width = double.NaN;
+                }
+            }
         }
 
         private async void FileListBox_MouseDoubleClick(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
## Summary
- add `sys` namespace in `MainWindow.xaml`
- set Key and Result columns' `Width` to `Double.NaN` to force auto-width
- reset column widths when `SitecoreDataGrid` data changes

## Testing
- `dotnet build PackageAnalyzer/PackageAnalyzer.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8c846c34832694b7427bd1889c6c