### PR TITLE
Add UI to configure excluded custom types

### DIFF
--- a/PackageAnalyzer/MainWindow.xaml
+++ b/PackageAnalyzer/MainWindow.xaml
@@ -77,19 +77,25 @@
                     <Button Content="Close" HorizontalAlignment="Right" Click="ClosePopup"/>
 
                     <!-- ListBox with CheckBoxes for Each Line -->
-                    <ListBox ItemsSource="{Binding KeySettings}">
+                    <ListBox x:Name="SettingsListBox">
                         <ListBox.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal" Margin="3">
-                                    <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}" 
-                                              Checked="KeySetting_Checked" 
-                                              Unchecked="KeySetting_Unchecked" 
+                                    <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                              Checked="PopupItem_Checked"
+                                              Unchecked="PopupItem_Unchecked"
                                               VerticalAlignment="Center" Margin="2"/>
                                     <TextBlock Text="{Binding Name}" VerticalAlignment="Center" Margin="2"/>
                                 </StackPanel>
                             </DataTemplate>
                         </ListBox.ItemTemplate>
                     </ListBox>
+
+                    <!-- Panel for adding new excluded types -->
+                    <StackPanel x:Name="AddCustomTypePanel" Orientation="Horizontal" Margin="0,5,0,0" Visibility="Collapsed">
+                        <TextBox x:Name="NewCustomTypeTextBox" Width="200"/>
+                        <Button Content="Add" Margin="5,0,0,0" Click="AddCustomType_Click"/>
+                    </StackPanel>
                 </StackPanel>
             </Border>
         </Popup>


### PR DESCRIPTION
## Summary
- Allow editing of excluded custom type prefixes via existing Settings popup
- Support adding new custom type prefixes and persist to configuration
- Reload custom types tab when exclusions change

## Testing
- `dotnet build PackageAnalyzer/PackageAnalyzer.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4208aa9208326a4a0aff482362727